### PR TITLE
ManagedShowdownClient: Allow updating the message throttle delay

### DIFF
--- a/src/client/managed.ts
+++ b/src/client/managed.ts
@@ -157,7 +157,7 @@ export class ManagedShowdownClient {
   private async attemptConnect() {
     this.loggedIn = false;
     await this.rawClient.connect();
-    this.handleQueue();
+    this.handleQueue(this.clientOptions.throttle);
   }
 
   private async connectWithRetry(delay: number, retries: number): Promise<void> {
@@ -372,7 +372,7 @@ export class ManagedShowdownClient {
     }
   }
 
-  private handleQueue() {
+  private handleQueue(throttle: number) {
     this.messageQueueInterval = setInterval(() => {
       if (!this.isConnected) {
         this.stopQueue();
@@ -384,7 +384,12 @@ export class ManagedShowdownClient {
         const message = this.messageQueue.deq();
         this.sendQueued(message);
       } catch (error) {} // eslint-disable-line no-empty
-    }, this.clientOptions.throttle);
+    }, throttle);
+  }
+
+  public updateQueueThrottle(throttle: number) {
+    this.stopQueue();
+    this.handleQueue(throttle);
   }
 
   private stopQueue() {


### PR DESCRIPTION
I wanted to add code for the bot to choose between message throttles after either checking its userdetails or its userauth, since PS main supports three different throttle delays (600 ms for regular users, 100 ms for trusted users, or 25 ms for public bots). This way, I wouldn't have to manually change the configured message throttle when working on the development version of my bot or when changing between servers.

It might be worth adding and exporting the constants from main for convenience, but the developer should probably be smart enough to determine an appropriate throttle themselves (or stick with the default message throttle, in any case); at least with this PR, they could do it during runtime.